### PR TITLE
Fix key listener target in DirectTypingEngine2

### DIFF
--- a/src/typing/DirectTypingEngine2.ts
+++ b/src/typing/DirectTypingEngine2.ts
@@ -279,12 +279,14 @@ export class DirectTypingEngine2 {  private state: DirectEngineState;
 
   /**
    * キーリスナー設定
-   */
+  */
   private setupKeyListener(): void {
-    if (document.body) {
-      document.body.tabIndex = -1;
-      document.body.focus();
-    }
+    if (!this.container) return;
+
+    // 🚀 コンテナをフォーカス可能にする
+    this.container.setAttribute('tabindex', '0');
+    this.container.style.outline = 'none';
+    this.container.focus();
 
     this.keyHandler = (e: KeyboardEvent) => {
       if (e.ctrlKey || e.altKey || e.metaKey || e.key.length !== 1) {
@@ -295,7 +297,10 @@ export class DirectTypingEngine2 {  private state: DirectEngineState;
       e.stopPropagation();
 
       this.processKey(e.key);
-    };    document.addEventListener('keydown', this.keyHandler, { capture: true });
+    };
+
+    // 🚀 Container-Scopedイベントリスナー
+    this.container.addEventListener('keydown', this.keyHandler, { capture: true });
     // 🚀 DirectTypingEngine2 キーリスナー設定完了
   }/**
    * キー処理


### PR DESCRIPTION
## Summary
- listen for key events on the engine container instead of the document
- focus the container on initialization so it receives keyboard events

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6851090b846c8325afff624489750f3e